### PR TITLE
feat: add Google Search Console verification tag

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -74,6 +74,10 @@ export default function RootLayout({
         <meta name="theme-color" content="#4F46E5" />
         <meta name="apple-mobile-web-app-title" content="monli" />
         <meta
+          name="google-site-verification"
+          content="gs8ipaSQ05xaS9r1ScKArsPcBLNQGIDw8OONjrt0eBM"
+        />
+        <meta
           name="description"
           content="monli adalah aplikasi pengelola keuangan pribadi yang membantu kamu mencatat pengeluaran, memonitor pemasukan, menyusun anggaran, dan memantau tabungan dalam satu tempat. Cerdas, mudah digunakan, dan dilengkapi grafik interaktif agar kamu bisa melihat gambaran keuangan secara utuh dan membuat keputusan finansial yang tepat."
         />


### PR DESCRIPTION
## Summary
- add Google site verification meta tag for Search Console

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run test:e2e` *(fails: fetch failed to download native next swc)*

------
https://chatgpt.com/codex/tasks/task_e_689eb67a3cd0832585ed093690905329