### PR TITLE
feat: make budgets account agnostic

### DIFF
--- a/app/(dashboard)/budgets/page.tsx
+++ b/app/(dashboard)/budgets/page.tsx
@@ -56,7 +56,7 @@ export default function BudgetsPage() {
     setTransactions,
     loading,
     setLoading,
-    getAccountMonthlySpending,
+    getMonthlySpending,
   } = useAppStore();
 
   const [year, setYear] = useState('all');
@@ -72,7 +72,7 @@ export default function BudgetsPage() {
         const { data: budgetsData } = await supabase
           .from('budgets')
           .select(
-            `*, account:accounts(*), items:budget_items(*, category:categories(*))`
+            `*, items:budget_items(*, category:categories(*))`
           )
           .eq('user_id', user.id);
         if (budgetsData) setBudgets(keysToCamel<Budget[]>(budgetsData));
@@ -112,7 +112,7 @@ export default function BudgetsPage() {
 
   const getBudgetTotals = (budget: Budget) => {
     const planned = budget.totalAmount;
-    const actual = getAccountMonthlySpending(budget.accountId, budget.month);
+    const actual = getMonthlySpending(budget.month);
     const progress = planned ? (actual / planned) * 100 : 0;
     const indicatorColor =
       progress < 70
@@ -136,8 +136,7 @@ export default function BudgetsPage() {
         <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <CardTitle className="text-base sm:text-lg">
-              {format(new Date(`${budget.month}-01`), 'MMMM yyyy')} –{' '}
-              {budget.account?.name}
+              {format(new Date(`${budget.month}-01`), 'MMMM yyyy')}
             </CardTitle>
           </div>
           <Button
@@ -221,7 +220,6 @@ export default function BudgetsPage() {
           <TableHeader>
             <TableRow>
               <TableHead>Bulan</TableHead>
-              <TableHead>Akun</TableHead>
               <TableHead className="text-right">Rencana</TableHead>
               <TableHead className="text-right">Terpakai</TableHead>
               <TableHead>Progress</TableHead>
@@ -237,7 +235,6 @@ export default function BudgetsPage() {
                   <TableCell>
                     {format(new Date(`${b.month}-01`), 'MMMM yyyy')}
                   </TableCell>
-                  <TableCell>{b.account?.name}</TableCell>
                   <TableCell className="text-right">
                     {formatIDR(planned)}
                   </TableCell>

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -142,7 +142,7 @@ export default function DashboardPage() {
         const { data: budgetsData } = await supabase
           .from('budgets')
           .select(
-            `*, account:accounts(*), items:budget_items(*, category:categories(*))`
+            `*, items:budget_items(*, category:categories(*))`
           )
           .eq('user_id', user.id)
           .eq('month', currentMonth);

--- a/app/api/budgets/[id]/route.ts
+++ b/app/api/budgets/[id]/route.ts
@@ -19,13 +19,12 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     };
     type Budget = Database['public']['Tables']['budgets']['Row'] & {
       items: BudgetItem[];
-      account_id: string;
       total_amount: number;
     };
     const { data: budget, error } = await supabase
       .from('budgets')
       .select(
-        'id, month, account_id, total_amount, items:budget_items(id, amount, rollover, category:categories(id, name, color))'
+        'id, month, total_amount, items:budget_items(id, amount, rollover, category:categories(id, name, color))'
       )
       .eq('id', params.id)
       .eq('user_id', user.id)
@@ -71,7 +70,6 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     return NextResponse.json({
       id: budget.id,
       month: budget.month,
-      accountId: budget.account_id,
       totalAmount: budget.total_amount,
       items,
     });
@@ -95,7 +93,7 @@ export async function PATCH(
     const user = await getUser();
     const { data: existing, error } = await supabase
       .from('budgets')
-      .select('id, month, account_id, total_amount, items:budget_items(id, category_id, amount, rollover)')
+      .select('id, month, total_amount, items:budget_items(id, category_id, amount, rollover)')
       .eq('id', params.id)
       .eq('user_id', user.id)
       .single();
@@ -110,25 +108,6 @@ export async function PATCH(
         .eq('user_id', user.id);
       if (monthError) {
         return NextResponse.json({ error: monthError.message }, { status: 400 });
-      }
-    }
-    if (body.accountId && body.accountId !== existing.account_id) {
-      const { data: acc } = await supabase
-        .from('accounts')
-        .select('id')
-        .eq('id', body.accountId)
-        .eq('user_id', user.id)
-        .single();
-      if (!acc) {
-        return NextResponse.json({ error: 'Invalid account' }, { status: 400 });
-      }
-      const { error: accError } = await supabase
-        .from('budgets')
-        .update({ account_id: body.accountId })
-        .eq('id', params.id)
-        .eq('user_id', user.id);
-      if (accError) {
-        return NextResponse.json({ error: accError.message }, { status: 400 });
       }
     }
     if (body.totalAmount !== undefined && body.totalAmount !== existing.total_amount) {
@@ -172,7 +151,7 @@ export async function PATCH(
     }
     const { data, error: fetchError } = await supabase
       .from('budgets')
-      .select('*, account:accounts(*), items:budget_items(*, category:categories(*))')
+      .select('*, items:budget_items(*, category:categories(*))')
       .eq('id', params.id)
       .eq('user_id', user.id)
       .single();

--- a/components/budgets/budget-detail-dialog.tsx
+++ b/components/budgets/budget-detail-dialog.tsx
@@ -77,7 +77,7 @@ export function BudgetDetailDialog({
     loading,
     setLoading,
     getCategorySpending,
-    getAccountMonthlySpending,
+    getMonthlySpending,
   } = useAppStore();
 
   const [budget, setBudget] = useState<Budget | null>(null);
@@ -95,9 +95,7 @@ export function BudgetDetailDialog({
         if (!budgets.find((b) => b.id === budgetId)) {
           const { data: budgetData } = await supabase
             .from('budgets')
-            .select(
-              `*, account:accounts(*), items:budget_items(*, category:categories(*))`
-            )
+            .select(`*, items:budget_items(*, category:categories(*))`)
             .eq('user_id', user.id)
             .eq('id', budgetId)
             .single();
@@ -165,9 +163,7 @@ export function BudgetDetailDialog({
   ]);
 
   const totalBudget = budget?.totalAmount ?? 0;
-  const totalSpent = budget
-    ? getAccountMonthlySpending(budget.accountId, budget.month)
-    : 0;
+  const totalSpent = budget ? getMonthlySpending(budget.month) : 0;
   const progress = totalBudget ? (totalSpent / totalBudget) * 100 : 0;
   const overallIndicatorColor =
     progress < 70
@@ -264,7 +260,6 @@ export function BudgetDetailDialog({
             >
               <DialogTitle className="text-xl sm:text-2xl font-bold break-words">
                 {format(new Date(`${budget.month}-01`), 'MMMM yyyy')}
-                {budget.account ? ` - ${budget.account.name}` : ''}
               </DialogTitle>
             </DialogHeader>
 
@@ -273,7 +268,6 @@ export function BudgetDetailDialog({
                 <CardHeader>
                   <CardTitle className="text-xl sm:text-2xl font-bold break-words">
                     {format(new Date(`${budget.month}-01`), 'MMMM yyyy')}
-                    {budget.account ? ` - ${budget.account.name}` : ''}
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-2">

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -21,7 +21,6 @@ interface AppState {
   getCurrentBalance: (accountId: string) => number;
   getCategorySpending: (categoryId: string, month: string) => number;
   getMonthlySpending: (month: string) => number;
-  getAccountMonthlySpending: (accountId: string, month: string) => number;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -88,26 +87,10 @@ export const useAppStore = create<AppState>((set, get) => ({
     const monthEnd = `${month}-31`;
     
     return transactions
-      .filter(t => 
+      .filter(t =>
         t.type === 'expense' &&
-        t.date >= monthStart && 
+        t.date >= monthStart &&
         t.date <= monthEnd
-      )
-      .reduce((sum, t) => sum + t.amount, 0);
-  },
-
-  getAccountMonthlySpending: (accountId: string, month: string) => {
-    const { transactions } = get();
-    const monthStart = `${month}-01`;
-    const monthEnd = `${month}-31`;
-
-    return transactions
-      .filter(
-        t =>
-          t.accountId === accountId &&
-          t.type === 'expense' &&
-          t.date >= monthStart &&
-          t.date <= monthEnd
       )
       .reduce((sum, t) => sum + t.amount, 0);
   },

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -42,14 +42,12 @@ export const budgetItemPatchSchema = budgetItemSchema.partial();
 
 export const budgetSchema = z.object({
   month: monthSchema,
-  accountId: z.string().uuid(),
   totalAmount: z.number().positive(),
   items: z.array(budgetItemSchema).default([]),
 });
 
 export const budgetPatchSchema = z.object({
   month: monthSchema.optional(),
-  accountId: z.string().uuid().optional(),
   totalAmount: z.number().positive().optional(),
   items: z.array(budgetItemSchema).optional(),
 });

--- a/supabase/migrations/20240506000000_remove_account_id_from_budgets.sql
+++ b/supabase/migrations/20240506000000_remove_account_id_from_budgets.sql
@@ -1,0 +1,4 @@
+-- Remove account_id from budgets table to make budgets account-agnostic
+alter table budgets drop constraint if exists budgets_user_id_month_account_id_key;
+alter table budgets drop column if exists account_id;
+alter table budgets add constraint budgets_user_id_month_key unique (user_id, month);

--- a/types/database.ts
+++ b/types/database.ts
@@ -92,7 +92,6 @@ export interface Database {
           id: string;
           user_id: string;
           month: string;
-          account_id: string;
           total_amount: number;
           created_at: string;
           updated_at: string;
@@ -101,14 +100,12 @@ export interface Database {
           id?: string;
           user_id: string;
           month: string;
-          account_id: string;
           total_amount?: number;
           created_at?: string;
           updated_at?: string;
         };
         Update: {
           month?: string;
-          account_id?: string;
           total_amount?: number;
           updated_at?: string;
         };

--- a/types/index.ts
+++ b/types/index.ts
@@ -29,10 +29,8 @@ export interface Budget {
   id: string;
   userId: string;
   month: string;
-  accountId: string;
   totalAmount: number;
   items: BudgetItem[];
-  account?: Account;
 }
 
 export interface BudgetItem {


### PR DESCRIPTION
## Summary
- remove account reference from budget model and API
- drop account selection from budget form
- compute budget spending across all accounts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ed9624ed083259fe7037ec303c4d6