### PR TITLE
Add sitemap for monli.fun and reference it in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+# robots.txt for Google Search indexing
+User-agent: *
+Allow: /
+
+Sitemap: https://monli.fun/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://monli.fun/</loc>
+  </url>
+  <url>
+    <loc>https://monli.fun/auth/sign-in</loc>
+  </url>
+  <url>
+    <loc>https://monli.fun/auth/sign-up</loc>
+  </url>
+  <url>
+    <loc>https://monli.fun/dashboard</loc>
+  </url>
+  <url>
+    <loc>https://monli.fun/accounts</loc>
+  </url>
+  <url>
+    <loc>https://monli.fun/budgets</loc>
+  </url>
+  <url>
+    <loc>https://monli.fun/transactions</loc>
+  </url>
+  <url>
+    <loc>https://monli.fun/reports</loc>
+  </url>
+  <url>
+    <loc>https://monli.fun/settings</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- create sitemap.xml covering current app routes
- point robots.txt to https://monli.fun/sitemap.xml

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f0dc6e6b88325bbc4573fdba10581