### PR TITLE
Improve recent transactions card and fix filter handling

### DIFF
--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -152,28 +152,28 @@ export default function ReportsPage() {
       </Collapsible>
 
       <Tabs defaultValue="summary" className="space-y-4">
-        <TabsList className="flex w-full overflow-x-auto gap-2 sm:overflow-visible">
+        <TabsList className="grid w-full grid-cols-2 gap-2 sm:flex sm:overflow-visible">
           <TabsTrigger
             value="summary"
-            className="flex-shrink-0 whitespace-nowrap min-w-[140px] sm:flex-1 sm:min-w-[120px]"
+            className="w-full whitespace-nowrap sm:flex-1"
           >
             Monthly Summary
           </TabsTrigger>
           <TabsTrigger
             value="trend"
-            className="flex-shrink-0 whitespace-nowrap min-w-[140px] sm:flex-1 sm:min-w-[120px]"
+            className="w-full whitespace-nowrap sm:flex-1"
           >
             Income vs Expense Trend
           </TabsTrigger>
           <TabsTrigger
             value="category"
-            className="flex-shrink-0 whitespace-nowrap min-w-[140px] sm:flex-1 sm:min-w-[120px]"
+            className="w-full whitespace-nowrap sm:flex-1"
           >
             Category Details
           </TabsTrigger>
           <TabsTrigger
             value="movement"
-            className="flex-shrink-0 whitespace-nowrap min-w-[140px] sm:flex-1 sm:min-w-[120px]"
+            className="w-full whitespace-nowrap sm:flex-1"
           >
             Budget vs Actual
           </TabsTrigger>

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -116,7 +116,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                 onChange={e => setFilters(f => ({ ...f, endDate: e.target.value }))}
               />
               <Select
-                value={filters.accountId}
+                value={filters.accountId || undefined}
                 onValueChange={value => setFilters(f => ({ ...f, accountId: value }))}
               >
                 <SelectTrigger>
@@ -124,7 +124,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="">All Accounts</SelectItem>
-                  {accounts.map(acc => (
+                  {accounts?.map(acc => (
                     <SelectItem key={acc.id} value={acc.id}>
                       {acc.name}
                     </SelectItem>
@@ -132,7 +132,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                 </SelectContent>
               </Select>
               <Select
-                value={filters.categoryId}
+                value={filters.categoryId || undefined}
                 onValueChange={value => setFilters(f => ({ ...f, categoryId: value }))}
               >
                 <SelectTrigger>
@@ -140,7 +140,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="">All Categories</SelectItem>
-                  {categories.map(cat => (
+                  {categories?.map(cat => (
                     <SelectItem key={cat.id} value={cat.id}>
                       {cat.name}
                     </SelectItem>
@@ -148,7 +148,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                 </SelectContent>
               </Select>
               <Select
-                value={filters.type}
+                value={filters.type || undefined}
                 onValueChange={value => setFilters(f => ({ ...f, type: value }))}
               >
                 <SelectTrigger>
@@ -179,24 +179,26 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
           </CollapsibleContent>
         </CardHeader>
         <CardContent>
-          <div className="space-y-4">
-            {filteredTransactions.length === 0 ? (
-              <p className="text-sm text-muted-foreground text-center py-4">
-                No transactions found.
-              </p>
-            ) : (
-              filteredTransactions.map(transaction => (
+          {filteredTransactions.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              No transactions found.
+            </p>
+          ) : (
+            <div className="divide-y rounded-md border">
+              {filteredTransactions.map(transaction => (
                 <div
                   key={transaction.id}
-                  className="flex items-center justify-between p-3 rounded-lg border"
+                  className="flex items-center justify-between p-4 hover:bg-muted/50 transition-colors"
                 >
-                  <div className="flex items-center space-x-3">
-                    {getTransactionIcon(transaction.type)}
-                    <div>
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted">
+                      {getTransactionIcon(transaction.type)}
+                    </div>
+                    <div className="space-y-1">
                       <p className="text-sm font-medium">
                         {getTransactionDescription(transaction)}
                       </p>
-                      <div className="flex items-center space-x-2 mt-1">
+                      <div className="flex items-center gap-2">
                         <p className="text-xs text-muted-foreground">
                           {format(parseISO(transaction.date), 'MMM dd, yyyy')}
                         </p>
@@ -206,7 +208,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                           </Badge>
                         )}
                         {transaction.tags && transaction.tags.length > 0 && (
-                          <div className="flex space-x-1">
+                          <div className="flex gap-1">
                             {transaction.tags.slice(0, 2).map(tag => (
                               <Badge key={tag} variant="secondary" className="text-xs">
                                 {tag}
@@ -222,7 +224,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                       </div>
                     </div>
                   </div>
-                  <div className="text-right">
+                  <div className="text-right space-y-1">
                     <p
                       className={`text-sm font-semibold ${
                         transaction.type === 'income'
@@ -237,15 +239,15 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                     </p>
                     <Badge
                       variant={getTransactionBadgeVariant(transaction.type)}
-                      className="text-xs mt-1"
+                      className="text-xs"
                     >
                       {transaction.type}
                     </Badge>
                   </div>
                 </div>
-              ))
-            )}
-          </div>
+              ))}
+            </div>
+          )}
         </CardContent>
       </Collapsible>
     </Card>

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -116,14 +116,16 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                 onChange={e => setFilters(f => ({ ...f, endDate: e.target.value }))}
               />
               <Select
-                value={filters.accountId || undefined}
-                onValueChange={value => setFilters(f => ({ ...f, accountId: value }))}
+                value={filters.accountId || 'all'}
+                onValueChange={value =>
+                  setFilters(f => ({ ...f, accountId: value === 'all' ? '' : value }))
+                }
               >
                 <SelectTrigger>
                   <SelectValue placeholder="Account" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">All Accounts</SelectItem>
+                  <SelectItem value="all">All Accounts</SelectItem>
                   {accounts?.map(acc => (
                     <SelectItem key={acc.id} value={acc.id}>
                       {acc.name}
@@ -132,14 +134,16 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                 </SelectContent>
               </Select>
               <Select
-                value={filters.categoryId || undefined}
-                onValueChange={value => setFilters(f => ({ ...f, categoryId: value }))}
+                value={filters.categoryId || 'all'}
+                onValueChange={value =>
+                  setFilters(f => ({ ...f, categoryId: value === 'all' ? '' : value }))
+                }
               >
                 <SelectTrigger>
                   <SelectValue placeholder="Category" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">All Categories</SelectItem>
+                  <SelectItem value="all">All Categories</SelectItem>
                   {categories?.map(cat => (
                     <SelectItem key={cat.id} value={cat.id}>
                       {cat.name}
@@ -148,14 +152,16 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                 </SelectContent>
               </Select>
               <Select
-                value={filters.type || undefined}
-                onValueChange={value => setFilters(f => ({ ...f, type: value }))}
+                value={filters.type || 'all'}
+                onValueChange={value =>
+                  setFilters(f => ({ ...f, type: value === 'all' ? '' : value }))
+                }
               >
                 <SelectTrigger>
                   <SelectValue placeholder="Type" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">All Types</SelectItem>
+                  <SelectItem value="all">All Types</SelectItem>
                   <SelectItem value="income">Income</SelectItem>
                   <SelectItem value="expense">Expense</SelectItem>
                   <SelectItem value="transfer">Transfer</SelectItem>


### PR DESCRIPTION
## Summary
- polish Recent Transactions list with a cleaner layout and hover states
- harden dashboard filters to avoid runtime errors when values are cleared

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run test:e2e` *(fails: Timed out waiting 60000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_689f61748af883258d5571e9caddd8f0