### PR TITLE
Improve report page responsiveness and enhance dashboard transactions

### DIFF
--- a/app/(dashboard)/loading.tsx
+++ b/app/(dashboard)/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-32 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -152,28 +152,28 @@ export default function ReportsPage() {
       </Collapsible>
 
       <Tabs defaultValue="summary" className="space-y-4">
-        <TabsList className="flex w-full overflow-x-auto gap-2 sm:overflow-visible">
+        <TabsList className="grid w-full grid-cols-2 gap-2 sm:flex sm:overflow-visible">
           <TabsTrigger
             value="summary"
-            className="flex-shrink-0 whitespace-nowrap min-w-[140px] sm:flex-1 sm:min-w-[120px]"
+            className="w-full whitespace-nowrap sm:flex-1"
           >
             Monthly Summary
           </TabsTrigger>
           <TabsTrigger
             value="trend"
-            className="flex-shrink-0 whitespace-nowrap min-w-[140px] sm:flex-1 sm:min-w-[120px]"
+            className="w-full whitespace-nowrap sm:flex-1"
           >
             Income vs Expense Trend
           </TabsTrigger>
           <TabsTrigger
             value="category"
-            className="flex-shrink-0 whitespace-nowrap min-w-[140px] sm:flex-1 sm:min-w-[120px]"
+            className="w-full whitespace-nowrap sm:flex-1"
           >
             Category Details
           </TabsTrigger>
           <TabsTrigger
             value="movement"
-            className="flex-shrink-0 whitespace-nowrap min-w-[140px] sm:flex-1 sm:min-w-[120px]"
+            className="w-full whitespace-nowrap sm:flex-1"
           >
             Budget vs Actual
           </TabsTrigger>

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -37,6 +37,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
 import {
   Popover,
   PopoverContent,
@@ -377,6 +378,7 @@ export default function TransactionsPage() {
               <TableHead>Title</TableHead>
               <TableHead>Date</TableHead>
               <TableHead>Account</TableHead>
+              <TableHead>Category</TableHead>
               <TableHead className="text-right">Amount</TableHead>
               <TableHead className="text-right">Actions</TableHead>
             </TableRow>
@@ -420,6 +422,15 @@ export default function TransactionsPage() {
                       t.fromAccount?.name ||
                       t.toAccount?.name ||
                       '-'}
+                  </TableCell>
+                  <TableCell>
+                    {t.category ? (
+                      <Badge variant="secondary" className="text-xs">
+                        {t.category.name}
+                      </Badge>
+                    ) : (
+                      '-'
+                    )}
                   </TableCell>
                   <TableCell className={cn('text-right font-medium', color)}>
                     {amountPrefix}
@@ -476,9 +487,39 @@ export default function TransactionsPage() {
                 {Icon && <Icon className="h-5 w-5" color={t.category?.color} />}
                 <div>
                   <p className="text-sm font-medium">{title}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {format(parseISO(t.date), 'MMM dd, yyyy')}
-                  </p>
+                  <div className="flex items-center gap-2">
+                    <p className="text-xs text-muted-foreground">
+                      {format(parseISO(t.date), 'MMM dd, yyyy')}
+                    </p>
+                    {t.type === 'transfer' ? (
+                      <>
+                        {t.fromAccount && (
+                          <Badge variant="outline" className="text-xs">
+                            {t.fromAccount.name}
+                          </Badge>
+                        )}
+                        {t.fromAccount && t.toAccount && (
+                          <span className="text-xs text-muted-foreground">→</span>
+                        )}
+                        {t.toAccount && (
+                          <Badge variant="outline" className="text-xs">
+                            {t.toAccount.name}
+                          </Badge>
+                        )}
+                      </>
+                    ) : (
+                      t.account && (
+                        <Badge variant="outline" className="text-xs">
+                          {t.account.name}
+                        </Badge>
+                      )
+                    )}
+                    {t.category && (
+                      <Badge variant="secondary" className="text-xs">
+                        {t.category.name}
+                      </Badge>
+                    )}
+                  </div>
                 </div>
               </div>
               <div className="text-right">

--- a/app/(marketing)/loading.tsx
+++ b/app/(marketing)/loading.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function Loading() {
+  return (
+    <div className="space-y-10">
+      <Skeleton className="mx-auto h-10 w-3/4" />
+      <div className="space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-6 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/auth/loading.tsx
+++ b/app/auth/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function Loading() {
+  return (
+    <div className="mx-auto w-full max-w-md space-y-4">
+      <Skeleton className="h-8 w-1/2" />
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Skeleton key={i} className="h-10 w-full" />
+      ))}
+      <Skeleton className="h-10 w-full" />
+    </div>
+  );
+}

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -186,7 +186,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                 {filteredTransactions.map(transaction => (
                   <m.div
                     key={transaction.id}
-                    className="flex items-center justify-between p-4 hover:bg-muted/50 transition-colors"
+                    className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 p-4 hover:bg-muted/50 transition-colors"
                     initial={{ opacity: 0, y: 8 }}
                     animate={{ opacity: 1, y: 0 }}
                   >
@@ -198,7 +198,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                         <p className="text-sm font-medium">
                           {getTransactionDescription(transaction)}
                         </p>
-                        <div className="flex items-center gap-2">
+                        <div className="flex flex-wrap items-center gap-2">
                           <p className="text-xs text-muted-foreground">
                             {format(parseISO(transaction.date), 'MMM dd, yyyy')}
                           </p>
@@ -231,7 +231,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                             </Badge>
                           )}
                           {transaction.tags && transaction.tags.length > 0 && (
-                            <div className="flex gap-1">
+                            <div className="flex flex-wrap gap-1">
                               {transaction.tags.slice(0, 2).map(tag => (
                                 <Badge key={tag} variant="secondary" className="text-xs">
                                   {tag}
@@ -247,7 +247,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                         </div>
                       </div>
                     </div>
-                    <div className="text-right">
+                    <div className="w-full text-right sm:w-auto">
                       <p
                         className={`text-sm font-semibold ${
                           transaction.type === 'income'

--- a/components/reports/category-movement-chart.tsx
+++ b/components/reports/category-movement-chart.tsx
@@ -12,6 +12,7 @@ import {
   Legend,
   ReferenceLine,
   ResponsiveContainer,
+  Label,
 } from 'recharts';
 import { Input } from '@/components/ui/input';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
@@ -34,6 +35,21 @@ export default function CategoryMovementChart() {
     setHidden((prev) => ({ ...prev, [key]: !prev[key] }));
 
   const chartData = data?.data ?? [];
+
+  const CustomizedAxisTick = ({ x, y, payload }: any) => (
+    <g transform={`translate(${x},${y})`}>
+      <text
+        x={0}
+        y={0}
+        dy={16}
+        textAnchor="end"
+        transform="rotate(-90)"
+        className="text-[10px]"
+      >
+        {payload.value}
+      </text>
+    </g>
+  );
 
   const CustomTooltip = ({ active, payload, label }: any) => {
     if (active && payload && payload.length) {
@@ -103,34 +119,33 @@ export default function CategoryMovementChart() {
         <div className="text-sm text-muted-foreground">No data</div>
       )}
       {chartData.length > 0 && (
-        <div className="overflow-x-auto">
-          <div className="h-72 min-w-[600px]">
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={chartData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis
-                  dataKey="category_name"
-                  interval={0}
-                  tickFormatter={(v: string) =>
-                    v.length > 10 ? `${v.slice(0, 10)}…` : v
-                  }
-                />
-                <YAxis tickFormatter={(v: number) => toIDR(v)} />
-                <Tooltip content={<CustomTooltip />} />
-                <Legend content={renderLegend} />
-                <ReferenceLine y={0} stroke="#888" />
-                {!hidden.planned && (
-                  <Line type="monotone" dataKey="planned" stroke="#3B82F6" dot />
-                )}
-                {!hidden.actual && (
-                  <Line type="monotone" dataKey="actual" stroke="#16a34a" dot />
-                )}
-                {!hidden.diff && (
-                  <Line type="monotone" dataKey="diff" stroke="#dc2626" dot />
-                )}
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
+        <div className="h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData} margin={{ bottom: 80 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="category_name"
+                interval={0}
+                height={70}
+                tick={<CustomizedAxisTick />}
+              >
+                <Label value="Categories" position="right" angle={90} dx={10} />
+              </XAxis>
+              <YAxis tickFormatter={(v: number) => toIDR(v)} />
+              <Tooltip content={<CustomTooltip />} />
+              <Legend content={renderLegend} />
+              <ReferenceLine y={0} stroke="#888" />
+              {!hidden.planned && (
+                <Line type="monotone" dataKey="planned" stroke="#3B82F6" dot />
+              )}
+              {!hidden.actual && (
+                <Line type="monotone" dataKey="actual" stroke="#16a34a" dot />
+              )}
+              {!hidden.diff && (
+                <Line type="monotone" dataKey="diff" stroke="#dc2626" dot />
+              )}
+            </LineChart>
+          </ResponsiveContainer>
         </div>
       )}
     </div>

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,16 +1,28 @@
 import * as React from 'react';
+import {
+  AlertCircle,
+  CheckCircle2,
+  Info,
+  TriangleAlert,
+} from 'lucide-react';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
 const alertVariants = cva(
-  'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
+  'relative flex w-full items-start gap-3 rounded-md border p-4',
   {
     variants: {
       variant: {
         default: 'bg-background text-foreground',
         destructive:
-          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+          'border-destructive/50 text-destructive bg-destructive/10',
+        success:
+          'border-green-500 text-green-700 bg-green-50 dark:border-green-800 dark:text-green-400 dark:bg-green-950',
+        warning:
+          'border-yellow-500 text-yellow-700 bg-yellow-50 dark:border-yellow-800 dark:text-yellow-400 dark:bg-yellow-950',
+        info:
+          'border-blue-500 text-blue-700 bg-blue-50 dark:border-blue-800 dark:text-blue-400 dark:bg-blue-950',
       },
     },
     defaultVariants: {
@@ -19,17 +31,31 @@ const alertVariants = cva(
   }
 );
 
+const iconMap = {
+  default: Info,
+  destructive: AlertCircle,
+  success: CheckCircle2,
+  warning: TriangleAlert,
+  info: Info,
+} as const;
+
 const Alert = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
->(({ className, variant, ...props }, ref) => (
-  <div
-    ref={ref}
-    role="alert"
-    className={cn(alertVariants({ variant }), className)}
-    {...props}
-  />
-));
+>(({ className, variant, children, ...props }, ref) => {
+  const Icon = iconMap[variant ?? 'default'];
+  return (
+    <div
+      ref={ref}
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    >
+      <Icon className="mt-0.5 h-5 w-5" />
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+});
 Alert.displayName = 'Alert';
 
 const AlertTitle = React.forwardRef<

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "embla-carousel-react": "^8.3.0",
         "eslint": "8.49.0",
         "eslint-config-next": "13.5.1",
+        "framer-motion": "^11.18.2",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.446.0",
         "next": "13.5.1",
@@ -4302,6 +4303,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5286,6 +5314,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "embla-carousel-react": "^8.3.0",
     "eslint": "8.49.0",
     "eslint-config-next": "13.5.1",
+    "framer-motion": "^11.18.2",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.446.0",
     "next": "13.5.1",


### PR DESCRIPTION
## Summary
- show account and category badges in transaction list cards and add a category column to the desktop table
- show account and category badges in Recent Transactions cards
- polish Recent Transactions list with a cleaner layout and hover states
- harden dashboard filters to avoid runtime errors when values are cleared
- replace empty SelectItem values with explicit 'all' option to fix filter click error
- reflow report tabs into a two-column grid on small screens for better mobile responsiveness
- orient budget-vs-actual chart categories vertically so long labels remain readable on mobile
- add skeleton loading states for dashboard, marketing, and auth routes
- refresh alert component with icons and color-coded variants for better UX
- animate Recent Transactions rows using framer-motion, loading motion features lazily
- remove transaction type label from dashboard cards to rely on icon and amount color

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run test:e2e` *(fails: fetch failed, ENETUNREACH during Next.js web server setup)*

------
https://chatgpt.com/codex/tasks/task_e_689f61748af883258d5571e9caddd8f0