### PR TITLE
feat: support budget month and actual date

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -79,7 +79,9 @@ export default function DashboardPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          date: formatDate(values.date),
+          budgetMonth: values.budgetMonth,
+          actualDate: formatDate(values.actualDate),
+          date: formatDate(values.actualDate),
           type: values.type,
           accountId: values.accountId,
           fromAccountId: values.fromAccountId,
@@ -201,7 +203,7 @@ export default function DashboardPage() {
     const monthlyBudget = currentBudgets.reduce((sum, b) => sum + b.totalAmount, 0);
     
     const monthlyActual = transactions
-      .filter(t => t.type === 'expense' && t.date.startsWith(currentMonth))
+      .filter(t => t.type === 'expense' && t.budgetMonth === currentMonth)
       .reduce((sum, t) => sum + t.amount, 0);
 
     // MTD spend (same as monthly actual for current month)
@@ -227,7 +229,7 @@ export default function DashboardPage() {
 
     transactions
       .filter(
-        t => t.type === 'expense' && t.date.startsWith(currentMonth)
+        t => t.type === 'expense' && t.budgetMonth === currentMonth
       )
       .forEach(t => {
         if (!t.categoryId || !t.category) return;

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo, Fragment } from 'react';
 import { format, parseISO } from 'date-fns';
 import * as LucideIcons from 'lucide-react';
 import { Plus, Pencil, Trash, Calendar as CalendarIcon } from 'lucide-react';
@@ -97,6 +97,17 @@ export default function TransactionsPage() {
   const [page, setPage] = useState(1);
   const pageSize = 20;
   const [total, setTotal] = useState(0);
+  const [dateField, setDateField] = useState<'actual' | 'budget'>('actual');
+  const [groupBy, setGroupBy] = useState<'actual' | 'budget'>('actual');
+
+  const groupedTransactions = useMemo(() => {
+    const groups: Record<string, Transaction[]> = {};
+    transactions.forEach((t) => {
+      const key = groupBy === 'budget' ? t.budgetMonth : t.actualDate.slice(0, 7);
+      (groups[key] = groups[key] || []).push(t);
+    });
+    return Object.entries(groups).sort((a, b) => b[0].localeCompare(a[0]));
+  }, [transactions, groupBy]);
 
   const fetchTransactions = useCallback(async () => {
     if (!user) return;
@@ -104,8 +115,21 @@ export default function TransactionsPage() {
       page: String(page),
       pageSize: String(pageSize),
     });
-    if (dateRange.from) params.set('from', formatDate(dateRange.from));
-    if (dateRange.to) params.set('to', formatDate(dateRange.to));
+    if (dateRange.from)
+      params.set(
+        'from',
+        dateField === 'budget'
+          ? format(dateRange.from, 'yyyy-MM')
+          : formatDate(dateRange.from)
+      );
+    if (dateRange.to)
+      params.set(
+        'to',
+        dateField === 'budget'
+          ? format(dateRange.to, 'yyyy-MM')
+          : formatDate(dateRange.to)
+      );
+    params.set('dateField', dateField);
     if (accountFilter !== 'all') params.set('accountId', accountFilter);
     if (categoryFilter !== 'all') params.set('categoryId', categoryFilter);
     if (typeFilter !== 'all') params.set('type', typeFilter);
@@ -124,6 +148,7 @@ export default function TransactionsPage() {
     pageSize,
     dateRange.from,
     dateRange.to,
+    dateField,
     accountFilter,
     categoryFilter,
     typeFilter,
@@ -171,7 +196,9 @@ export default function TransactionsPage() {
   const handleSave = async (values: TransactionFormValues) => {
     if (!user) return;
     const payload = {
-      date: formatDate(values.date),
+      budgetMonth: values.budgetMonth,
+      actualDate: formatDate(values.actualDate),
+      date: formatDate(values.actualDate),
       type: values.type,
       accountId: values.accountId,
       fromAccountId: values.fromAccountId,
@@ -266,7 +293,7 @@ export default function TransactionsPage() {
       {/* Filters */}
       <div className="flex flex-col md:flex-row md:flex-wrap gap-2">
         <Popover>
-          <PopoverTrigger asChild>
+      <PopoverTrigger asChild>
             <Button
               variant="outline"
               className={cn(
@@ -298,6 +325,35 @@ export default function TransactionsPage() {
             />
           </PopoverContent>
       </Popover>
+
+      <Select
+        value={groupBy}
+        onValueChange={(v) => setGroupBy(v as 'actual' | 'budget')}
+      >
+        <SelectTrigger className="w-full md:w-[180px]">
+          <SelectValue placeholder="Group by" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="budget">Budget month</SelectItem>
+          <SelectItem value="actual">Actual date month</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={dateField}
+        onValueChange={(v) => {
+          setDateField(v as 'actual' | 'budget');
+          setPage(1);
+        }}
+      >
+        <SelectTrigger className="w-full md:w-[180px]">
+          <SelectValue placeholder="Filter month by" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="budget">Budget</SelectItem>
+          <SelectItem value="actual">Actual</SelectItem>
+        </SelectContent>
+      </Select>
 
       <Select
         value={accountFilter}
@@ -382,11 +438,91 @@ export default function TransactionsPage() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {transactions.map((t) => {
+            {groupedTransactions.map(([month, txs]) => (
+              <Fragment key={month}>
+                <TableRow>
+                  <TableCell colSpan={6} className="font-medium">
+                    {format(parseISO(`${month}-01`), 'MMM yyyy')}
+                  </TableCell>
+                </TableRow>
+                {txs.map((t) => {
+                  const Icon = t.category?.icon
+                    ? (LucideIcons[
+                        t.category.icon as keyof typeof LucideIcons
+                      ] as any)
+                    : null;
+                  const title =
+                    t.note ||
+                    t.category?.name ||
+                    (t.type === 'transfer'
+                      ? `Transfer from ${t.fromAccount?.name} to ${t.toAccount?.name}`
+                      : 'No description');
+                  const color =
+                    t.type === 'income'
+                      ? 'text-green-600'
+                      : t.type === 'expense'
+                      ? 'text-red-600'
+                      : 'text-blue-600';
+                  const amountPrefix = t.type === 'expense' ? '-' : '';
+                  return (
+                    <TableRow key={t.id}>
+                      <TableCell className="p-0">
+                        {Icon && (
+                          <Icon
+                            className="h-4 w-4"
+                            color={t.category?.color}
+                          />
+                        )}
+                      </TableCell>
+                      <TableCell>{title}</TableCell>
+                      <TableCell>
+                        {format(parseISO(t.actualDate), 'MMM dd, yyyy')}
+                      </TableCell>
+                      <TableCell>
+                        {t.account?.name ||
+                          t.fromAccount?.name ||
+                          t.toAccount?.name ||
+                          '-'}
+                      </TableCell>
+                      <TableCell className={cn('text-right font-medium', color)}>
+                        {amountPrefix}
+                        {formatIDR(t.amount)}
+                      </TableCell>
+                      <TableCell className="text-right space-x-2">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => openEdit(t)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleDeleteRow(t)}
+                        >
+                          <Trash className="h-4 w-4" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </Fragment>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Mobile Cards */}
+      <div className="md:hidden space-y-4">
+        {groupedTransactions.map(([month, txs]) => (
+          <div key={month} className="space-y-2">
+            <h3 className="text-sm font-medium px-1">
+              {format(parseISO(`${month}-01`), 'MMM yyyy')}
+            </h3>
+            {txs.map((t) => {
               const Icon = t.category?.icon
-                ? (LucideIcons[
-                    t.category.icon as keyof typeof LucideIcons
-                  ] as any)
+                ? (LucideIcons[t.category.icon as keyof typeof LucideIcons] as any)
                 : null;
               const title =
                 t.note ||
@@ -402,110 +538,46 @@ export default function TransactionsPage() {
                   : 'text-blue-600';
               const amountPrefix = t.type === 'expense' ? '-' : '';
               return (
-                <TableRow key={t.id}>
-                  <TableCell className="p-0">
-                    {Icon && (
-                      <Icon
-                        className="h-4 w-4"
-                        color={t.category?.color}
-                      />
-                    )}
-                  </TableCell>
-                  <TableCell>{title}</TableCell>
-                  <TableCell>
-                    {format(parseISO(t.date), 'MMM dd, yyyy')}
-                  </TableCell>
-                  <TableCell>
-                    {t.account?.name ||
-                      t.fromAccount?.name ||
-                      t.toAccount?.name ||
-                      '-'}
-                  </TableCell>
-                  <TableCell className={cn('text-right font-medium', color)}>
-                    {amountPrefix}
-                    {formatIDR(t.amount)}
-                  </TableCell>
-                  <TableCell className="text-right space-x-2">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => openEdit(t)}
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => handleDeleteRow(t)}
-                    >
-                      <Trash className="h-4 w-4" />
-                    </Button>
-                  </TableCell>
-                </TableRow>
+                <Card
+                  key={t.id}
+                  className="p-4 flex items-center justify-between"
+                >
+                  <div className="flex items-center space-x-3">
+                    {Icon && <Icon className="h-5 w-5" color={t.category?.color} />}
+                    <div>
+                      <p className="text-sm font-medium">{title}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {format(parseISO(t.actualDate), 'MMM dd, yyyy')}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className={cn('text-sm font-semibold', color)}>
+                      {amountPrefix}
+                      {formatIDR(t.amount)}
+                    </p>
+                    <div className="flex justify-end space-x-1 mt-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => openEdit(t)}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleDeleteRow(t)}
+                      >
+                        <Trash className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </Card>
               );
             })}
-          </TableBody>
-        </Table>
-      </div>
-
-      {/* Mobile Cards */}
-      <div className="md:hidden space-y-2">
-        {transactions.map((t) => {
-          const Icon = t.category?.icon
-            ? (LucideIcons[t.category.icon as keyof typeof LucideIcons] as any)
-            : null;
-          const title =
-            t.note ||
-            t.category?.name ||
-            (t.type === 'transfer'
-              ? `Transfer from ${t.fromAccount?.name} to ${t.toAccount?.name}`
-              : 'No description');
-          const color =
-            t.type === 'income'
-              ? 'text-green-600'
-              : t.type === 'expense'
-              ? 'text-red-600'
-              : 'text-blue-600';
-          const amountPrefix = t.type === 'expense' ? '-' : '';
-          return (
-            <Card
-              key={t.id}
-              className="p-4 flex items-center justify-between"
-            >
-              <div className="flex items-center space-x-3">
-                {Icon && <Icon className="h-5 w-5" color={t.category?.color} />}
-                <div>
-                  <p className="text-sm font-medium">{title}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {format(parseISO(t.date), 'MMM dd, yyyy')}
-                  </p>
-                </div>
-              </div>
-              <div className="text-right">
-                <p className={cn('text-sm font-semibold', color)}>
-                  {amountPrefix}
-                  {formatIDR(t.amount)}
-                </p>
-                <div className="flex justify-end space-x-1 mt-1">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => openEdit(t)}
-                  >
-                    <Pencil className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => handleDeleteRow(t)}
-                  >
-                    <Trash className="h-4 w-4" />
-                  </Button>
-                </div>
-              </div>
-            </Card>
-          );
-        })}
+          </div>
+        ))}
       </div>
 
       {pageCount > 1 && (

--- a/app/api/budgets/route.ts
+++ b/app/api/budgets/route.ts
@@ -29,23 +29,16 @@ export async function GET(req: Request) {
     }
     const { data: tx, error: txError } = await supabase
       .from('transactions')
-      .select('amount, date')
+      .select('amount, budget_month')
       .eq('user_id', user.id)
       .eq('type', 'expense')
-      .gte('date', `${year}-01-01`)
-      .lt('date', `${Number(year) + 1}-01-01`);
+      .like('budget_month', `${year}-%`);
     if (txError) {
       return NextResponse.json({ error: txError.message }, { status: 400 });
     }
     const actualByMonth: Record<string, number> = {};
     for (const t of tx || []) {
-      const monthKey = new Date(t.date)
-        .toLocaleDateString('en-CA', {
-          timeZone: 'Asia/Jakarta',
-          year: 'numeric',
-          month: '2-digit',
-        })
-        .slice(0, 7);
+      const monthKey = t.budget_month;
       actualByMonth[monthKey] = (actualByMonth[monthKey] || 0) + t.amount;
     }
     const result = budgets.map(b => ({

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -90,7 +90,9 @@ export async function PATCH(
     const { data, error } = await supabase
       .from('transactions')
       .update({
-        date: body.date,
+        date: body.actualDate,
+        actual_date: body.actualDate,
+        budget_month: body.budgetMonth,
         type: newType,
         account_id: newAccountId,
         from_account_id: newFrom,

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -29,14 +29,15 @@ export async function GET(req: Request) {
 
     const from = searchParams.get('from');
     const to = searchParams.get('to');
+    const dateField = searchParams.get('dateField') === 'budget' ? 'budget_month' : 'actual_date';
     const type = searchParams.get('type');
     const accountId = searchParams.get('accountId');
     const categoryId = searchParams.get('categoryId');
     const tags = searchParams.get('tags');
     const search = searchParams.get('search');
 
-    if (from) query = query.gte('date', from);
-    if (to) query = query.lte('date', to);
+    if (from) query = query.gte(dateField, from);
+    if (to) query = query.lte(dateField, to);
     if (type) query = query.eq('type', type);
     if (categoryId) query = query.eq('category_id', categoryId);
     if (accountId)
@@ -54,7 +55,7 @@ export async function GET(req: Request) {
     }
 
     const { data, error, count } = await query
-      .order('date', { ascending: false })
+      .order(dateField, { ascending: false })
       .order('created_at', { ascending: false })
       .range(fromIdx, toIdx);
     if (error) {
@@ -102,7 +103,9 @@ export async function POST(req: Request) {
       .from('transactions')
       .insert({
         user_id: user.id,
-        date: body.date,
+        date: body.actualDate,
+        actual_date: body.actualDate,
+        budget_month: body.budgetMonth,
         type: body.type,
         account_id: body.accountId,
         from_account_id: body.fromAccountId,

--- a/components/dashboard/dashboard-charts.tsx
+++ b/components/dashboard/dashboard-charts.tsx
@@ -35,7 +35,7 @@ export function DashboardCharts({ transactions, categorySpends }: Props) {
     return days.map(day => {
       const dateStr = format(day, 'yyyy-MM-dd');
       const dayExpenses = transactions
-        .filter(t => t.type === 'expense' && t.date === dateStr)
+        .filter(t => t.type === 'expense' && t.actualDate === dateStr)
         .reduce((sum, t) => sum + t.amount, 0);
 
       return {

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -40,7 +40,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
 
   const filteredTransactions = useMemo(() => {
     return transactions.filter(t => {
-      const txDate = new Date(t.date).getTime();
+      const txDate = new Date(t.actualDate).getTime();
       if (filters.startDate && txDate < new Date(filters.startDate).getTime())
         return false;
       if (filters.endDate && txDate > new Date(filters.endDate).getTime())
@@ -206,7 +206,7 @@ export function RecentTransactions({ transactions, accounts, categories }: Props
                       </p>
                       <div className="flex items-center gap-2">
                         <p className="text-xs text-muted-foreground">
-                          {format(parseISO(transaction.date), 'MMM dd, yyyy')}
+                          {format(parseISO(transaction.actualDate), 'MMM dd, yyyy')}
                         </p>
                         {transaction.account && (
                           <Badge variant="outline" className="text-xs">

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -38,7 +38,9 @@ export function MobileNav() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          date: formatDate(values.date),
+          budgetMonth: values.budgetMonth,
+          actualDate: formatDate(values.actualDate),
+          date: formatDate(values.actualDate),
           type: values.type,
           accountId: values.accountId,
           fromAccountId: values.fromAccountId,

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -68,29 +68,21 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   getCategorySpending: (categoryId: string, month: string) => {
     const { transactions } = get();
-    const monthStart = `${month}-01`;
-    const monthEnd = `${month}-31`;
-    
     return transactions
-      .filter(t => 
-        t.categoryId === categoryId && 
-        t.type === 'expense' &&
-        t.date >= monthStart && 
-        t.date <= monthEnd
+      .filter(
+        (t) =>
+          t.categoryId === categoryId &&
+          t.type === 'expense' &&
+          t.budgetMonth === month
       )
       .reduce((sum, t) => sum + t.amount, 0);
   },
 
   getMonthlySpending: (month: string) => {
     const { transactions } = get();
-    const monthStart = `${month}-01`;
-    const monthEnd = `${month}-31`;
-    
     return transactions
-      .filter(t =>
-        t.type === 'expense' &&
-        t.date >= monthStart &&
-        t.date <= monthEnd
+      .filter(
+        (t) => t.type === 'expense' && t.budgetMonth === month
       )
       .reduce((sum, t) => sum + t.amount, 0);
   },

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -52,8 +52,14 @@ export const budgetPatchSchema = z.object({
   items: z.array(budgetItemSchema).optional(),
 });
 
+const dateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/);
+
 const transactionBaseSchema = z.object({
-  date: z.string(),
+  budgetMonth: monthSchema,
+  actualDate: dateSchema,
+  date: dateSchema.optional(),
   type: z.enum(['expense', 'income', 'transfer']),
   accountId: z.string().uuid().nullable().optional(),
   fromAccountId: z.string().uuid().nullable().optional(),

--- a/supabase/migrations/20240814000000_add_budget_month_actual_date.sql
+++ b/supabase/migrations/20240814000000_add_budget_month_actual_date.sql
@@ -1,0 +1,10 @@
+alter table transactions add column if not exists budget_month text;
+alter table transactions add column if not exists actual_date date;
+
+update transactions set actual_date = created_at::date, budget_month = to_char(date, 'YYYY-MM');
+
+alter table transactions alter column actual_date set not null;
+alter table transactions alter column budget_month set not null;
+
+alter table transactions alter column actual_date set default (timezone('utc', now()))::date;
+alter table transactions alter column budget_month set default to_char(timezone('utc', now()), 'YYYY-MM');

--- a/types/database.ts
+++ b/types/database.ts
@@ -141,6 +141,8 @@ export interface Database {
           id: string;
           user_id: string;
           date: string;
+          actual_date: string;
+          budget_month: string;
           type: 'expense' | 'income' | 'transfer';
           account_id: string | null;
           from_account_id: string | null;
@@ -156,6 +158,8 @@ export interface Database {
           id?: string;
           user_id: string;
           date: string;
+          actual_date?: string;
+          budget_month?: string;
           type: 'expense' | 'income' | 'transfer';
           account_id?: string | null;
           from_account_id?: string | null;
@@ -169,6 +173,8 @@ export interface Database {
         };
         Update: {
           date?: string;
+          actual_date?: string;
+          budget_month?: string;
           type?: 'expense' | 'income' | 'transfer';
           account_id?: string | null;
           from_account_id?: string | null;

--- a/types/index.ts
+++ b/types/index.ts
@@ -46,7 +46,10 @@ export interface BudgetItem {
 export interface Transaction {
   id: string;
   userId: string;
+  /** @deprecated use actualDate */
   date: string;
+  actualDate: string;
+  budgetMonth: string;
   type: 'expense' | 'income' | 'transfer';
   accountId?: string;
   fromAccountId?: string;


### PR DESCRIPTION
## Summary
- split transactions into budget month and actual date fields
- add month/date inputs and filtering options in transaction UI
- adjust API, validation, and store logic for new fields

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a7da0aec8325b1f7a7aedbffa02b