### PR TITLE
Enhance report CSV export and mobile download button

### DIFF
--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -88,11 +88,24 @@ export default function ReportsPage() {
       .catch(() => setCategoryData([]));
   }, [month]);
 
-  const exportCSV = (rows: any[], filename: string) => {
+  const exportCSV = (
+    rows: Record<string, unknown>[],
+    filename: string,
+    keys?: string[]
+  ) => {
     if (!rows.length) return;
-    const headers = Object.keys(rows[0]).join(',');
-    const csv =
-      headers + '\n' + rows.map((r) => Object.values(r).join(',')).join('\n');
+    const cols = keys ?? Object.keys(rows[0]);
+    const escape = (value: unknown) => {
+      const str = String(value ?? '');
+      return /[",\n]/.test(str)
+        ? '"' + str.replace(/"/g, '""') + '"'
+        : str;
+    };
+    const header = cols.join(',');
+    const lines = rows.map((r) =>
+      cols.map((k) => escape((r as Record<string, unknown>)[k])).join(',')
+    );
+    const csv = [header, ...lines].join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
@@ -106,6 +119,58 @@ export default function ReportsPage() {
     date: d.date.slice(8, 10),
     amount: d.amount,
   }));
+
+  const exportDailyCSV = () => {
+    let running = 0;
+    const rows = summary.daily.map((d) => {
+      running += d.amount;
+      return {
+        date: d.date,
+        day: d.date.slice(8, 10),
+        amount: d.amount,
+        cumulative: running,
+      };
+    });
+    exportCSV(rows, `daily-${month}.csv`, [
+      'date',
+      'day',
+      'amount',
+      'cumulative',
+    ]);
+  };
+
+  const exportTrendCSV = () => {
+    const rows = trend.map((t) => ({
+      month: t.month,
+      income: t.income,
+      expense: t.expense,
+      balance: t.income - t.expense,
+    }));
+    exportCSV(rows, `trend-${year}.csv`, [
+      'month',
+      'income',
+      'expense',
+      'balance',
+    ]);
+  };
+
+  const exportCategoryCSV = () => {
+    const total = categoryData.reduce((sum, c) => sum + c.amount, 0);
+    const rows = categoryData.map((c) => ({
+      categoryId: c.categoryId,
+      name: c.name,
+      amount: c.amount,
+      percentage: total ? Number(((c.amount / total) * 100).toFixed(2)) : 0,
+      color: c.color,
+    }));
+    exportCSV(rows, `categories-${month}.csv`, [
+      'categoryId',
+      'name',
+      'amount',
+      'percentage',
+      'color',
+    ]);
+  };
 
   return (
     <div className="space-y-6 px-2 sm:px-4 md:px-8">
@@ -152,7 +217,7 @@ export default function ReportsPage() {
       </Collapsible>
 
       <Tabs defaultValue="summary" className="space-y-4">
-        <TabsList className="grid w-full grid-cols-2 gap-2 sm:flex sm:overflow-visible">
+        <TabsList className="grid h-auto w-full grid-cols-2 gap-2 sm:flex sm:h-10 sm:overflow-visible">
           <TabsTrigger
             value="summary"
             className="w-full whitespace-nowrap sm:flex-1"
@@ -185,7 +250,7 @@ export default function ReportsPage() {
               variant="outline"
               size="sm"
               className="gap-1 w-full sm:w-auto"
-              onClick={() => exportCSV(summary.daily, `daily-${month}.csv`)}
+              onClick={exportDailyCSV}
             >
               <Download className="h-4 w-4" /> Export CSV
             </Button>
@@ -274,7 +339,7 @@ export default function ReportsPage() {
               variant="outline"
               size="sm"
               className="gap-1 w-full sm:w-auto"
-              onClick={() => exportCSV(trend, `trend-${year}.csv`)}
+              onClick={exportTrendCSV}
             >
               <Download className="h-4 w-4" /> Export CSV
             </Button>
@@ -307,7 +372,7 @@ export default function ReportsPage() {
               variant="outline"
               size="sm"
               className="gap-1 w-full sm:w-auto"
-              onClick={() => exportCSV(categoryData, `categories-${month}.csv`)}
+              onClick={exportCategoryCSV}
             >
               <Download className="h-4 w-4" /> Export CSV
             </Button>

--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -408,7 +408,7 @@ export default function ReportsPage() {
         </TabsContent>
 
         <TabsContent value="movement" className="space-y-4">
-          <CategoryMovementChart />
+          <CategoryMovementChart month={month} />
         </TabsContent>
       </Tabs>
     </div>

--- a/components/reports/category-movement-chart.tsx
+++ b/components/reports/category-movement-chart.tsx
@@ -29,7 +29,8 @@ export default function CategoryMovementChart({ month }: { month: string }) {
     fetch(`/api/reports/budget-vs-actual?month=${month}&type=expense`)
       .then((res) => res.json())
       .then((res: ChartResponse) => {
-        setChartData(res.data || []);
+        const filtered = (res.data || []).filter((d) => d.planned > 0);
+        setChartData(filtered);
         setError(false);
       })
       .catch(() => {

--- a/components/reports/category-movement-chart.tsx
+++ b/components/reports/category-movement-chart.tsx
@@ -13,16 +13,10 @@ import {
   ResponsiveContainer,
   Label,
 } from 'recharts';
-import { Input } from '@/components/ui/input';
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { toIDR } from '@/lib/currency';
 import type { ChartResponse } from '@/types';
 
-export default function CategoryMovementChart() {
-  const now = new Date();
-  const defaultMonth = now.toISOString().slice(0, 7);
-  const [month, setMonth] = useState(defaultMonth);
-  const [type, setType] = useState<'expense' | 'income'>('expense');
+export default function CategoryMovementChart({ month }: { month: string }) {
   const [chartData, setChartData] = useState<ChartResponse['data']>([]);
   const [error, setError] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -32,7 +26,7 @@ export default function CategoryMovementChart() {
 
   useEffect(() => {
     setLoading(true);
-    fetch(`/api/reports/budget-vs-actual?month=${month}&type=${type}`)
+    fetch(`/api/reports/budget-vs-actual?month=${month}&type=expense`)
       .then((res) => res.json())
       .then((res: ChartResponse) => {
         setChartData(res.data || []);
@@ -43,7 +37,7 @@ export default function CategoryMovementChart() {
         setError(true);
       })
       .finally(() => setLoading(false));
-  }, [month, type]);
+  }, [month]);
 
   const CustomizedAxisTick = ({ x, y, payload }: any) => (
     <g transform={`translate(${x},${y})`}>
@@ -100,24 +94,6 @@ export default function CategoryMovementChart() {
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-        <Input
-          type="month"
-          value={month}
-          onChange={(e) => setMonth(e.target.value)}
-          className="w-full sm:w-fit"
-          aria-label="Month"
-        />
-        <ToggleGroup
-          type="single"
-          value={type}
-          onValueChange={(v) => setType((v as any) || 'expense')}
-          className="w-full sm:w-fit"
-        >
-          <ToggleGroupItem value="expense">Expense</ToggleGroupItem>
-          <ToggleGroupItem value="income">Income</ToggleGroupItem>
-        </ToggleGroup>
-      </div>
       {error && (
         <div className="text-sm text-destructive">Failed to load data</div>
       )}

--- a/components/reports/category-movement-chart.tsx
+++ b/components/reports/category-movement-chart.tsx
@@ -56,7 +56,7 @@ export default function CategoryMovementChart({ month }: { month: string }) {
     if (active && payload && payload.length) {
       const p = payload.find((p: any) => p.dataKey === 'planned')?.value ?? 0;
       const a = payload.find((p: any) => p.dataKey === 'actual')?.value ?? 0;
-      const d = p - a;
+      const d = payload.find((p: any) => p.dataKey === 'diff')?.value ?? 0;
       const diffPct = p > 0 ? (d / p) * 100 : 0;
       return (
         <div className="rounded border bg-background p-2 text-xs">
@@ -100,8 +100,9 @@ export default function CategoryMovementChart({ month }: { month: string }) {
               <Tooltip content={<CustomTooltip />} />
               <Legend />
               <ReferenceLine y={0} stroke="#888" />
-              <Line type="monotone" dataKey="planned" stroke="#3B82F6" dot />
-              <Line type="monotone" dataKey="actual" stroke="#16a34a" dot />
+              <Line type="monotone" dataKey="planned" stroke="#3B82F6" dot name="Planned" />
+              <Line type="monotone" dataKey="actual" stroke="#16a34a" dot name="Actual" />
+              <Line type="monotone" dataKey="diff" stroke="#dc2626" dot name="Diff" />
             </LineChart>
           </ResponsiveContainer>
         </div>

--- a/components/reports/category-movement-chart.tsx
+++ b/components/reports/category-movement-chart.tsx
@@ -20,9 +20,6 @@ export default function CategoryMovementChart({ month }: { month: string }) {
   const [chartData, setChartData] = useState<ChartResponse['data']>([]);
   const [error, setError] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [hidden, setHidden] = useState<{ [k: string]: boolean }>({});
-  const toggleLine = (key: string) =>
-    setHidden((prev) => ({ ...prev, [key]: !prev[key] }));
 
   useEffect(() => {
     setLoading(true);
@@ -59,7 +56,7 @@ export default function CategoryMovementChart({ month }: { month: string }) {
     if (active && payload && payload.length) {
       const p = payload.find((p: any) => p.dataKey === 'planned')?.value ?? 0;
       const a = payload.find((p: any) => p.dataKey === 'actual')?.value ?? 0;
-      const d = payload.find((p: any) => p.dataKey === 'diff')?.value ?? 0;
+      const d = p - a;
       const diffPct = p > 0 ? (d / p) * 100 : 0;
       return (
         <div className="rounded border bg-background p-2 text-xs">
@@ -73,24 +70,6 @@ export default function CategoryMovementChart({ month }: { month: string }) {
       );
     }
     return null;
-  };
-
-  const renderLegend = (props: any) => {
-    const { payload } = props;
-    return (
-      <div className="flex flex-wrap gap-4 text-xs">
-        {payload.map((entry: any) => (
-          <label key={entry.dataKey} className="flex items-center gap-1">
-            <input
-              type="checkbox"
-              checked={!hidden[entry.dataKey]}
-              onChange={() => toggleLine(entry.dataKey)}
-            />
-            {entry.value}
-          </label>
-        ))}
-      </div>
-    );
   };
 
   return (
@@ -119,17 +98,10 @@ export default function CategoryMovementChart({ month }: { month: string }) {
               </XAxis>
               <YAxis tickFormatter={(v: number) => toIDR(v)} />
               <Tooltip content={<CustomTooltip />} />
-              <Legend content={renderLegend} />
+              <Legend />
               <ReferenceLine y={0} stroke="#888" />
-              {!hidden.planned && (
-                <Line type="monotone" dataKey="planned" stroke="#3B82F6" dot />
-              )}
-              {!hidden.actual && (
-                <Line type="monotone" dataKey="actual" stroke="#16a34a" dot />
-              )}
-              {!hidden.diff && (
-                <Line type="monotone" dataKey="diff" stroke="#dc2626" dot />
-              )}
+              <Line type="monotone" dataKey="planned" stroke="#3B82F6" dot />
+              <Line type="monotone" dataKey="actual" stroke="#16a34a" dot />
             </LineChart>
           </ResponsiveContainer>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
         "react-resizable-panels": "^2.1.3",
         "recharts": "^3.1.2",
         "sonner": "^1.5.0",
-        "swr": "^2.2.4",
         "tailwind-merge": "^2.5.2",
         "tailwindcss": "3.3.3",
         "tailwindcss-animate": "^1.0.7",
@@ -6847,19 +6846,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/swr": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.4.tgz",
-      "integrity": "sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "client-only": "^0.0.1",
-        "use-sync-external-store": "^1.2.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/tailwind-merge": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "react-resizable-panels": "^2.1.3",
     "recharts": "^3.1.2",
     "sonner": "^1.5.0",
-    "swr": "^2.2.4",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary
- Provide richer CSV data by adding daily running totals, monthly balance, and category percentages
- Wire download buttons to export the enriched datasets while keeping the download button responsive on mobile

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0c8da2f688325aadb792446c9ee87